### PR TITLE
Fix event listener and YouTube URL

### DIFF
--- a/resources/js/components/PYouTube.vue
+++ b/resources/js/components/PYouTube.vue
@@ -17,7 +17,7 @@
 
   if (typeof window?.YT?.Player === 'undefined') {
     const yt = document.createElement('script')
-    yt.src = 'https:///www.youtube.com/iframe_api'
+    yt.src = 'https://www.youtube.com/iframe_api'
     document.body.append(yt)
   }
 

--- a/resources/js/composables/UseDirectionalKeys.js
+++ b/resources/js/composables/UseDirectionalKeys.js
@@ -101,5 +101,5 @@ export default function useDirectionalKeys (element) {
     }
   }
 
-  element.addEventLisenter('keydown', handler)
+  element.addEventListener('keydown', handler)
 }


### PR DESCRIPTION
## Summary
- fix typo `addEventLisenter` -> `addEventListener`
- correct YouTube iframe API script URL

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68471beace008321bbd8894b45ea4e86