### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/resources/Overview.md
+++ b/resources/Overview.md
@@ -52,7 +52,7 @@ useComposableName.js
 
 * Vue directive files should be named in UpperCamelCase and prefixed with 'v'. *Example: vDirectionals.js.*
 * Pronto's Vue components should be prefixed with P and follow Vue naming conventions. Other components do not need to use the P prefix. *Example: PAccordion.vue.*
-* Vue composables only need to folow Vue naming conventions.
+* Vue composables only need to follow Vue naming conventions.
 
 ## Goals
 

--- a/resources/styles/imported/Properties.md
+++ b/resources/styles/imported/Properties.md
@@ -43,4 +43,4 @@ The default block and inline padding for elements.
 
 `--accent-color` is meant to be overridden, and represent the accent color for a component, similar to the `accent-color` CSS property. Pronto components will try to use this color, and expect that the contrast between this color and white to be sufficient for accessibility.
 
-It works with the color utilities (imported/utilities/colors) to allow all Pronto components to be re-colorable with the color utility classes. It's recommended that, instead of component-specific modifiers for changing the color of components, that you use `--accent-color` and define as necessary addditional color utility classes.
+It works with the color utilities (imported/utilities/colors) to allow all Pronto components to be re-colorable with the color utility classes. It's recommended that, instead of component-specific modifiers for changing the color of components, that you use `--accent-color` and define as necessary additional color utility classes.

--- a/resources/styles/imported/base.scss
+++ b/resources/styles/imported/base.scss
@@ -56,7 +56,7 @@ video {
 }
 
 /**
- * Disable double-tap to zoom on interative elements to avoid confusion.
+ * Disable double-tap to zoom on interactive elements to avoid confusion.
  */
 a[href],
 area,

--- a/resources/styles/imported/mixins/breakpoints.scss
+++ b/resources/styles/imported/mixins/breakpoints.scss
@@ -12,11 +12,11 @@ $breakpoints: (
 ) !default;
 
 /**
- * Handles both changin $breakpoints as well as defining the CSS properties for
+ * Handles both changing $breakpoints as well as defining the CSS properties for
  * the breakpoints. Usage:
  *
  * @param $breakpoints  map of breakpoints, with the keys being used as the
- *                      breakpoint names. If not specified, used the global
+ *                      breakpoint names. If not specified, use the global
  *                      $breakpoints value.
  * Usage:
  *


### PR DESCRIPTION
## Summary
- correct spelling mistakes across docs and SCSS files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68471cf92a008321b210acb04c0976da