### PR TITLE
Slider accessibility

### DIFF
--- a/public/main-icons-sprite.svg
+++ b/public/main-icons-sprite.svg
@@ -49,6 +49,10 @@
   <symbol viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg" id="play">
     <path d="M15.5 8.16228C16.1667 8.54718 16.1667 9.50943 15.5 9.89433L6.5 15.0905C5.83333 15.4754 5 14.9943 5 14.2245L5 3.83215C5 3.06235 5.83333 2.58122 6.5 2.96612L15.5 8.16228Z" fill="var(--icon-color, currentColor)"/>
   </symbol>
+  <symbol viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg" id="pause">
+    <rect x="3" y="2" width="4" height="15" rx="1" fill="var(--icon-color, currentColor)"/>
+    <rect x="11" y="2" width="4" height="15" rx="1" fill="var(--icon-color, currentColor)"/>
+  </symbol>
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 12" id="tag">
     <path d="M0.5 5.90902V1.125C0.5 0.503672 1.00367 0 1.625 0H6.40902C6.70739 1.56018e-06 6.99353 0.118529 7.20451 0.329508L12.1705 5.29549C12.6098 5.73483 12.6098 6.44714 12.1705 6.88648L7.38648 11.6705C6.94714 12.1098 6.23483 12.1098 5.79549 11.6705L0.829508 6.70451C0.618529 6.49353 0.500002 6.20739 0.5 5.90902H0.5ZM3.125 1.5C2.50367 1.5 2 2.00367 2 2.625C2 3.24633 2.50367 3.75 3.125 3.75C3.74633 3.75 4.25 3.24633 4.25 2.625C4.25 2.00367 3.74633 1.5 3.125 1.5Z" fill="var(--icon-color, currentColor)"></path>
   </symbol>

--- a/resources/js/components/PSlider.vue
+++ b/resources/js/components/PSlider.vue
@@ -60,20 +60,31 @@ const init = e => {
 
   swiperInstance.wrapperEl.setAttribute('aria-atomic', 'false')
 
-  // Pause autoplay whenever keyboard focus moves within the carousel while playing.
+  // Pause autoplay on user interaction (focus or intentional click) while playing.
   // Listens on both the host (slotted play button) and swiper.el (shadow DOM controls).
   // Skips the play/pause button so clicking it to resume does not immediately re-pause.
   if (props.autoplay) {
-    const pauseAutoplayOnFocus = (event) => {
-      if (event.target.closest?.('.slider__playPause')) return
+    const stopAutoplay = () => {
       if (!isPlaying.value) return
       swiperInstance.autoplay.stop()
       swiperInstance.wrapperEl.setAttribute('aria-live', 'polite')
       isPlaying.value = false
     }
 
+    const pauseAutoplayOnFocus = (event) => {
+      if (event.target.closest?.('.slider__playPause')) return
+      stopAutoplay()
+    }
+
+    // Pause on click of a slide, pagination bullet, or prev/next nav button.
+    const pauseAutoplayOnClick = (event) => {
+      if (!event.target.closest('.swiper-slide, .swiper-pagination-bullet, .swiper-button-prev, .swiper-button-next')) return
+      stopAutoplay()
+    }
+
     e.target.addEventListener('focusin', pauseAutoplayOnFocus)
     swiperInstance.el.addEventListener('focusin', pauseAutoplayOnFocus)
+    swiperInstance.el.addEventListener('click', pauseAutoplayOnClick)
   }
 
   if (swiperInstance.pagination?.el) {

--- a/resources/js/components/PSlider.vue
+++ b/resources/js/components/PSlider.vue
@@ -1,10 +1,13 @@
 <script setup>
 import { register } from 'swiper/element/bundle'
-import { ref } from 'vue'
+import { computed, ref, useAttrs } from 'vue'
 
 register()
 
-const slides = ref([])
+const attrs = useAttrs()
+const hasAutoplay = computed(() => !!attrs.autoplay)
+const isPlaying = ref(true)
+
 const props = defineProps({
   ariaLabel: {
     type: String,
@@ -12,9 +15,24 @@ const props = defineProps({
   },
 })
 
+let swiperInstance = null
+
+const toggleAutoplay = () => {
+  if (!swiperInstance) return
+
+  if (isPlaying.value) {
+    swiperInstance.autoplay.stop()
+    swiperInstance.wrapperEl.setAttribute('aria-live', 'polite')
+  } else {
+    swiperInstance.autoplay.start()
+    swiperInstance.wrapperEl.setAttribute('aria-live', 'off')
+  }
+  isPlaying.value = !isPlaying.value
+}
+
 const init = e => {
-  const swiperInstance = e.detail[0]
-  slides.value = swiperInstance?.slides
+  swiperInstance = e.detail[0]
+  const slides = swiperInstance?.slides
 
   // The following code is for slider accessibility
   // Please see the slider README.md or the W3C carousel pattern for more information:
@@ -27,13 +45,26 @@ const init = e => {
   // This should be customized for each carousel via props
   e.target.setAttribute('aria-label', props.ariaLabel)
 
-
-  // Swiper wrapper
+  // Swiper wrapper - aria-live is "off" while autoplaying to avoid interrupting the user
   swiperInstance.wrapperEl.setAttribute('aria-atomic', 'false')
+  swiperInstance.wrapperEl.setAttribute('aria-live', hasAutoplay.value ? 'off' : 'polite')
+
+  // Pause autoplay the first time keyboard focus enters the carousel
+  // { once: true } removes the listener after it fires so subsequent focus events
+  // (e.g. tabbing to the play button and continuing) don't re-stop user-initiated playback
+  if (hasAutoplay.value) {
+    e.target.addEventListener('focusin', () => {
+      if (isPlaying.value) {
+        swiperInstance.autoplay.stop()
+        swiperInstance.wrapperEl.setAttribute('aria-live', 'polite')
+        isPlaying.value = false
+      }
+    }, { once: true })
+  }
 
   // Swiper correctly sets role="group" per slide and aria-label to index/total slides
   // we still need to set aria-roledescription to "slide"
-  slides.value.forEach((slide) => {
+  slides.forEach((slide) => {
     slide.setAttribute('aria-roledescription', 'slide')
   })
 
@@ -42,7 +73,7 @@ const init = e => {
   swiperInstance.pagination.el.setAttribute('aria-label', 'Choose a slide')
 
   // Swiper pagination bullets
-  // set active bullet to aria-disabled=true, this updates with each slide change
+  // set active bullet to aria-disabled="true", this updates with each slide change
   const updateActiveBullet = (swiper) => {
     swiper.pagination.bullets.forEach((bullet) => {
       bullet.setAttribute('aria-disabled', bullet.classList.contains('swiper-pagination-bullet-active') ? 'true' : 'false')
@@ -55,7 +86,19 @@ const init = e => {
 }
 </script>
 <template>
-  <swiper-container ref="swiper" v-bind="$attrs" @swiperafterinit="init">
+  <swiper-container v-bind="$attrs" @swiperafterinit="init">
+    <!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -- native web component slot, not Vue 2 slot syntax -->
+    <button
+      v-if="hasAutoplay"
+      slot="container-start"
+      class="slider__playPause button -circle"
+      :aria-label="isPlaying ? 'Stop slide rotation' : 'Start slide rotation'"
+      @click="toggleAutoplay"
+    >
+      <svg class="button__icon" aria-hidden="true">
+        <use :href="isPlaying ? '/main-icons-sprite.svg#pause' : '/main-icons-sprite.svg#play'" />
+      </svg>
+    </button>
     <slot />
   </swiper-container>
 </template>

--- a/resources/js/components/PSlider.vue
+++ b/resources/js/components/PSlider.vue
@@ -1,19 +1,25 @@
 <script setup>
 import { register } from 'swiper/element/bundle'
-import { computed, ref, useAttrs } from 'vue'
+import { ref } from 'vue'
 
 register()
-
-const attrs = useAttrs()
-const hasAutoplay = computed(() => !!attrs.autoplay)
-const isPlaying = ref(true)
 
 const props = defineProps({
   ariaLabel: {
     type: String,
-    required: true,
+    default: undefined,
+  },
+  ariaLabelledby: {
+    type: String,
+    default: undefined,
+  },
+  autoplay: {
+    type: [Boolean, Object],
+    default: undefined,
   },
 })
+
+const isPlaying = ref(!!props.autoplay)
 
 let swiperInstance = null
 
@@ -30,66 +36,69 @@ const toggleAutoplay = () => {
   isPlaying.value = !isPlaying.value
 }
 
+const updateActiveBullet = (swiper) => {
+  if (!swiper.pagination?.bullets) return
+  swiper.pagination.bullets.forEach((bullet) => {
+    bullet.setAttribute('aria-disabled', bullet.classList.contains('swiper-pagination-bullet-active') ? 'true' : 'false')
+  })
+}
+
 const init = e => {
   swiperInstance = e.detail[0]
-  const slides = swiperInstance?.slides
 
-  // The following code is for slider accessibility
+  // The following code is for slider accessibility not covered by Swiper's a11y module.
   // Please see the slider README.md or the W3C carousel pattern for more information:
   // README: ../../../styles/organisms/slider/README.md
   // W3C: https://www.w3.org/WAI/ARIA/apg/patterns/carousel/
 
-  // Main swiper container
-  e.target.setAttribute('role', 'group')
-  e.target.setAttribute('aria-roledescription', 'carousel')
-  // This should be customized for each carousel via props
-  e.target.setAttribute('aria-label', props.ariaLabel)
+  // Swiper has no param for aria-labelledby; set it on the inner .swiper container
+  // (swiperInstance.el), matching where the a11y module applies aria-label
+  if (props.ariaLabelledby) {
+    swiperInstance.el.setAttribute('aria-labelledby', props.ariaLabelledby)
+    swiperInstance.el.removeAttribute('aria-label')
+  }
 
-  // Swiper wrapper - aria-live is "off" while autoplaying to avoid interrupting the user
   swiperInstance.wrapperEl.setAttribute('aria-atomic', 'false')
-  swiperInstance.wrapperEl.setAttribute('aria-live', hasAutoplay.value ? 'off' : 'polite')
 
-  // Pause autoplay the first time keyboard focus enters the carousel
-  // { once: true } removes the listener after it fires so subsequent focus events
-  // (e.g. tabbing to the play button and continuing) don't re-stop user-initiated playback
-  if (hasAutoplay.value) {
-    e.target.addEventListener('focusin', () => {
-      if (isPlaying.value) {
-        swiperInstance.autoplay.stop()
-        swiperInstance.wrapperEl.setAttribute('aria-live', 'polite')
-        isPlaying.value = false
-      }
-    }, { once: true })
+  // Pause autoplay whenever keyboard focus moves within the carousel while playing.
+  // Listens on both the host (slotted play button) and swiper.el (shadow DOM controls).
+  // Skips the play/pause button so clicking it to resume does not immediately re-pause.
+  if (props.autoplay) {
+    const pauseAutoplayOnFocus = (event) => {
+      if (event.target.closest?.('.slider__playPause')) return
+      if (!isPlaying.value) return
+      swiperInstance.autoplay.stop()
+      swiperInstance.wrapperEl.setAttribute('aria-live', 'polite')
+      isPlaying.value = false
+    }
+
+    e.target.addEventListener('focusin', pauseAutoplayOnFocus)
+    swiperInstance.el.addEventListener('focusin', pauseAutoplayOnFocus)
   }
 
-  // Swiper correctly sets role="group" per slide and aria-label to index/total slides
-  // we still need to set aria-roledescription to "slide"
-  slides.forEach((slide) => {
-    slide.setAttribute('aria-roledescription', 'slide')
-  })
-
-  // Swiper pagination wrapper
-  swiperInstance.pagination.el.setAttribute('role', 'group')
-  swiperInstance.pagination.el.setAttribute('aria-label', 'Choose a slide')
-
-  // Swiper pagination bullets
-  // set active bullet to aria-disabled="true", this updates with each slide change
-  const updateActiveBullet = (swiper) => {
-    swiper.pagination.bullets.forEach((bullet) => {
-      bullet.setAttribute('aria-disabled', bullet.classList.contains('swiper-pagination-bullet-active') ? 'true' : 'false')
-    })
+  if (swiperInstance.pagination?.el) {
+    swiperInstance.pagination.el.setAttribute('role', 'group')
+    swiperInstance.pagination.el.setAttribute('aria-label', 'Choose a slide')
   }
 
+  // Active bullet aria-disabled per W3C carousel pattern (Swiper sets aria-current only)
   updateActiveBullet(swiperInstance)
   swiperInstance.on('slideChange', updateActiveBullet)
-
+  swiperInstance.on('paginationUpdate', updateActiveBullet)
 }
 </script>
 <template>
-  <swiper-container v-bind="$attrs" @swiperafterinit="init">
-    <!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -- native web component slot, not Vue 2 slot syntax -->
+  <swiper-container
+    v-bind="$attrs"
+    :autoplay="autoplay"
+    a11y-container-role="group"
+    a11y-container-role-description-message="carousel"
+    :a11y-container-message="ariaLabel"
+    a11y-item-role-description-message="slide"
+    @swiperafterinit="init"
+  >
     <button
-      v-if="hasAutoplay"
+      v-if="autoplay"
       slot="container-start"
       class="slider__playPause button -circle"
       :aria-label="isPlaying ? 'Stop slide rotation' : 'Start slide rotation'"

--- a/resources/js/components/PSlider.vue
+++ b/resources/js/components/PSlider.vue
@@ -1,26 +1,61 @@
 <script setup>
 import { register } from 'swiper/element/bundle'
-import { ref, useTemplateRef } from 'vue'
+import { ref } from 'vue'
 
 register()
 
-const swiper = ref(null)
 const slides = ref([])
-const swiperEl = useTemplateRef('swiper')
+const props = defineProps({
+  ariaLabel: {
+    type: String,
+    required: true,
+  },
+})
 
 const init = e => {
-  slides.value = e.target.swiper?.slides
-  console.log(e.target, e.target?.swiper, swiperEl.value)
+  const swiperInstance = e.detail[0]
+  slides.value = swiperInstance?.slides
+
+  // The following code is for slider accessibility
+  // Please see the slider README.md or the W3C carousel pattern for more information:
+  // README: ../../../styles/organisms/slider/README.md
+  // W3C: https://www.w3.org/WAI/ARIA/apg/patterns/carousel/
+
+  // Main swiper container
+  e.target.setAttribute('role', 'group')
+  e.target.setAttribute('aria-roledescription', 'carousel')
+  // This should be customized for each carousel via props
+  e.target.setAttribute('aria-label', props.ariaLabel)
+
+
+  // Swiper wrapper
+  swiperInstance.wrapperEl.setAttribute('aria-atomic', 'false')
+
+  // Swiper correctly sets role="group" per slide and aria-label to index/total slides
+  // we still need to set aria-roledescription to "slide"
+  slides.value.forEach((slide) => {
+    slide.setAttribute('aria-roledescription', 'slide')
+  })
+
+  // Swiper pagination wrapper
+  swiperInstance.pagination.el.setAttribute('role', 'group')
+  swiperInstance.pagination.el.setAttribute('aria-label', 'Choose a slide')
+
+  // Swiper pagination bullets
+  // set active bullet to aria-disabled=true, this updates with each slide change
+  const updateActiveBullet = (swiper) => {
+    swiper.pagination.bullets.forEach((bullet) => {
+      bullet.setAttribute('aria-disabled', bullet.classList.contains('swiper-pagination-bullet-active') ? 'true' : 'false')
+    })
+  }
+
+  updateActiveBullet(swiperInstance)
+  swiperInstance.on('slideChange', updateActiveBullet)
+
 }
 </script>
 <template>
   <swiper-container ref="swiper" v-bind="$attrs" @swiperafterinit="init">
     <slot />
   </swiper-container>
-
-  <ul>
-    <li v-for="(slide, i) of slides" :key="i">
-      {{ i }}
-    </li>
-  </ul>
 </template>

--- a/resources/styles/organisms/cards/index.scss
+++ b/resources/styles/organisms/cards/index.scss
@@ -1,4 +1,4 @@
-@use '@imarc/pronto/resources/styles/imported' as *;
+@use '@/core' as *;
 
 .cards {
   $b: &;

--- a/resources/styles/organisms/slider/README.md
+++ b/resources/styles/organisms/slider/README.md
@@ -1,0 +1,67 @@
+# Accessibility Guidelines for Carousel Elements
+
+Please see the [W3C carousel pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) for more detail.
+
+Swiper's web component instance currently contains some, but not all, of the accessibility features needed for carousels.
+
+The rest are added in `PSlider.vue`, but here we are documenting the full requirements for reference when updating older sliders or creating new ones with different libraries.
+
+## Basic Slider — Not Autoplaying
+
+### Main Carousel Container
+
+The element that contains all slides and controls:
+
+- Must have `role="group"` — or `role="region"` if it contains vital page information (e.g. a product slider)
+- Must have `aria-roledescription="carousel"`
+- Must have `aria-label` or `aria-labelledby` — use `aria-labelledby="headingID"` if the carousel has a primary heading. The label should not contain the word "carousel", as it is already conveyed by `aria-roledescription`
+
+### Direct Wrapper Parent of Slides
+
+- `aria-atomic="false"` — directs the live region to announce only the node that changed, not the entire container
+- `aria-live="polite"` — directs the carousel to announce changing slides to screen readers without interrupting ongoing speech
+
+### Slide
+
+- Must have `role="group"`
+- Must have `aria-roledescription="slide"`
+- Must have `aria-label="index / total slides"` or `aria-labelledby="slide heading ID"`
+
+### Previous Slide / Next Slide Buttons
+
+- Should be native `&lt;button&gt;` elements — if not, must have:
+  - `role="button"`
+  - `aria-label="Next slide"` / `aria-label="Previous slide"`
+- Optional: `aria-controls="ID of the direct wrapper of slides"`
+
+### Pagination Bullet Wrapper
+
+- Must have `role="group"`
+- Must have `aria-label="Choose a slide"`
+
+### Pagination Bullets
+
+- Must have `aria-label="Go to slide {index}"` — label must match or contain the corresponding slide label
+- The active bullet must have:
+  - `aria-current="true"`
+  - `aria-disabled="true"` (preferred over the HTML `disabled` attribute, so the button remains in the tab sequence)
+
+> **Note:** Pagination bullets and previous/next slide controls should ideally be `&lt;button&gt;` elements. If they are not, they must have `role="button"` and an `aria-label`. They must be activatable with `Enter` or `Space` and must be reachable via keyboard tab navigation.
+
+## Additional Instructions for Autoplaying Sliders
+
+### Rotation Control (Play/Pause Button)
+
+- Must be the first element within the carousel/slider container
+- Should be a native `&lt;button&gt;` element — if not, must have `role="button"`
+- Must have an accessible label provided by either its inner text or `aria-label`. The label changes to match the action the button will perform, e.g., "Stop slide rotation" or "Start slide rotation". A label that changes when the button is activated clearly communicates both that slide content can change automatically and when it is doing so. Note that since the label changes, the rotation control does not have any states, e.g., `aria-pressed`, specified.
+
+### Autoplay Behavior
+
+- Autoplay pauses when keyboard focus enters the carousel and does not resume unless the play button is engaged by the user
+- Autoplay pauses on mouse hover of the carousel, but may resume when the cursor moves away
+
+### Direct Wrapper Parent of Slides (Autoplaying)
+
+- `aria-live="off"` — while the carousel is autoplaying, suppresses slide change announcements to avoid interrupting the user
+- `aria-live="polite"` — updates to `polite` when autoplay is stopped, so slide changes are announced to screen readers without interrupting ongoing speech

--- a/resources/styles/organisms/slider/README.md
+++ b/resources/styles/organisms/slider/README.md
@@ -1,67 +1,41 @@
-# Accessibility Guidelines for Carousel Elements
+# Accessibility Guidelines for PSlider
 
-Please see the [W3C carousel pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) for more detail.
+Please see the [W3C carousel pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) for more detail. We also have full guidelines for carousel attributes and functionality in [Outline](https://imarc.getoutline.com/doc/carousel-accessibility-SB2GKM2wJt).
 
-Swiper's web component instance currently contains some, but not all, of the accessibility features needed for carousels.
+`PSlider` wraps Swiper's `swiper-container` web component. Swiper's a11y module is enabled by default and handles most carousel accessibility automatically. `PSlider` configures the remaining Swiper options and adds a few attributes Swiper does not support.
 
-The rest are added in `PSlider.vue`, but here we are documenting the full requirements for reference when updating older sliders or creating new ones with different libraries.
+## Swiper a11y Options
 
-## Basic Slider — Not Autoplaying
+These are the configurable options Swiper's a11y module provides. On `<p-slider>`, they are passed as `a11y-*` kebab-case attributes (e.g. `a11y-prev-slide-message="Go back"`). Options configured by `PSlider` should not be overridden on individual carousels.
 
-### Main Carousel Container
+- `a11y-enabled` — Swiper default: `true`
+- `a11y-container-role` — Swiper default: none; PSlider default: `"group"`
+- `a11y-container-role-description-message` — Swiper default: none; PSlider default: `"carousel"`
+- `a11y-container-message` — Swiper default: none; PSlider: set from `ariaLabel` prop
+- `a11y-item-role-description-message` — Swiper default: none; PSlider default: `"slide"`
+- `a11y-slide-role` — Swiper default: `"group"`
+- `a11y-slide-label-message` — Swiper default: `"{{index}} / {{slidesLength}}"`
+- `a11y-prev-slide-message` — Swiper default: `"Previous slide"`
+- `a11y-next-slide-message` — Swiper default: `"Next slide"`
+- `a11y-first-slide-message` — Swiper default: `"This is the first slide"`
+- `a11y-last-slide-message` — Swiper default: `"This is the last slide"`
+- `a11y-pagination-bullet-message` — Swiper default: `"Go to slide {{index}}"`
+- `a11y-id` — Swiper default: none (auto-generated on the slide wrapper)
+- `a11y-scroll-on-focus` — Swiper default: `true`
 
-The element that contains all slides and controls:
+## Using PSlider
 
-- Must have `role="group"` — or `role="region"` if it contains vital page information (e.g. a product slider)
-- Must have `aria-roledescription="carousel"`
-- Must have `aria-label` or `aria-labelledby` — use `aria-labelledby="headingID"` if the carousel has a primary heading. The label should not contain the word "carousel", as it is already conveyed by `aria-roledescription`
+### Required
 
-### Direct Wrapper Parent of Slides
+- `aria-label` or `aria-labelledby` — every carousel must have an accessible name. Use `aria-labelledby` if the carousel has a primary heading — see `testimonialSlider.html`. Use `aria-label` if there is no heading — see `slider.html`. The label should not contain the word "carousel", as it is already conveyed by `aria-roledescription`.
+- `navigation="true"` — required for prev/next controls
+- `pagination-clickable="true"` — required for pagination bullets
 
-- `aria-atomic="false"` — directs the live region to announce only the node that changed, not the entire container
-- `aria-live="polite"` — directs the carousel to announce changing slides to screen readers without interrupting ongoing speech
+### Autoplaying Sliders
 
-### Slide
+- `autoplay` prop — enables the play/pause button, focus-pause behavior, and `aria-live` management
+- `pauseOnMouseEnter: true` in the autoplay config — see `slider--autoplaying.html` for a full example
 
-- Must have `role="group"`
-- Must have `aria-roledescription="slide"`
-- Must have `aria-label="index / total slides"` or `aria-labelledby="slide heading ID"`
 
-### Previous Slide / Next Slide Buttons
+`:autoplay="{ speed: 500, pauseOnMouseEnter: true }"`
 
-- Should be native `&lt;button&gt;` elements — if not, must have:
-  - `role="button"`
-  - `aria-label="Next slide"` / `aria-label="Previous slide"`
-- Optional: `aria-controls="ID of the direct wrapper of slides"`
-
-### Pagination Bullet Wrapper
-
-- Must have `role="group"`
-- Must have `aria-label="Choose a slide"`
-
-### Pagination Bullets
-
-- Must have `aria-label="Go to slide {index}"` — label must match or contain the corresponding slide label
-- The active bullet must have:
-  - `aria-current="true"`
-  - `aria-disabled="true"` (preferred over the HTML `disabled` attribute, so the button remains in the tab sequence)
-
-> **Note:** Pagination bullets and previous/next slide controls should ideally be `&lt;button&gt;` elements. If they are not, they must have `role="button"` and an `aria-label`. They must be activatable with `Enter` or `Space` and must be reachable via keyboard tab navigation.
-
-## Additional Instructions for Autoplaying Sliders
-
-### Rotation Control (Play/Pause Button)
-
-- Must be the first element within the carousel/slider container
-- Should be a native `&lt;button&gt;` element — if not, must have `role="button"`
-- Must have an accessible label provided by either its inner text or `aria-label`. The label changes to match the action the button will perform, e.g., "Stop slide rotation" or "Start slide rotation". A label that changes when the button is activated clearly communicates both that slide content can change automatically and when it is doing so. Note that since the label changes, the rotation control does not have any states, e.g., `aria-pressed`, specified.
-
-### Autoplay Behavior
-
-- Autoplay pauses when keyboard focus enters the carousel and does not resume unless the play button is engaged by the user
-- Autoplay pauses on mouse hover of the carousel, but may resume when the cursor moves away
-
-### Direct Wrapper Parent of Slides (Autoplaying)
-
-- `aria-live="off"` — while the carousel is autoplaying, suppresses slide change announcements to avoid interrupting the user
-- `aria-live="polite"` — updates to `polite` when autoplay is stopped, so slide changes are announced to screen readers without interrupting ongoing speech

--- a/resources/styles/organisms/slider/index.scss
+++ b/resources/styles/organisms/slider/index.scss
@@ -15,6 +15,13 @@
     }
   }
 
+  &__playPause {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 2;
+  }
+
   swiper-slide {
     width: 100cqw;
     height: auto;

--- a/resources/styles/organisms/slider/slider--autoplaying.html
+++ b/resources/styles/organisms/slider/slider--autoplaying.html
@@ -1,7 +1,7 @@
 <div class="slider">
   <div class="slider__content">
     <!-- aria-label should be customized for each carousel, and should not contain the word "carousel" -->
-    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, please customize for that use case -->
+    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, see testimonialSlider.html for an example -->
     <!-- when autoplaying, pause on mouse enter is required for accessibility -->
     <p-slider
       slides-per-view="auto"

--- a/resources/styles/organisms/slider/slider--autoplaying.html
+++ b/resources/styles/organisms/slider/slider--autoplaying.html
@@ -1,0 +1,32 @@
+<div class="slider">
+  <div class="slider__content">
+    <!-- aria-label should be customized for each carousel, and should not contain the word "carousel" -->
+    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, please customize for that use case -->
+    <!-- when autoplaying, pause on mouse enter is required for accessibility -->
+    <p-slider
+      slides-per-view="auto"
+      space-between="16"
+      navigation="true"
+      pagination-clickable="true"
+      loop="true"
+      aria-label="This should be customized for each carousel"
+      :autoplay="{
+        speed: 500,
+        pauseOnMouseEnter: true,
+      }"
+      :breakpoints="{
+      768: 
+        {
+          spaceBetween: 32,
+        },
+      }"
+    >
+      <swiper-slide loading="lazy" class="placeholder">Slide 1</swiper-slide>
+      <swiper-slide loading="lazy" class="placeholder">Slide 2</swiper-slide>
+      <swiper-slide loading="lazy" class="placeholder">Slide 3</swiper-slide>
+      <swiper-slide loading="lazy" class="placeholder">Slide 4</swiper-slide>
+      <swiper-slide loading="lazy" class="placeholder" style="aspect-ratio: 16 / 9">Wide</swiper-slide>
+      <swiper-slide loading="lazy" class="placeholder">Slide 6</swiper-slide>
+    </p-slider>
+  </div>
+</div>

--- a/resources/styles/organisms/slider/slider.html
+++ b/resources/styles/organisms/slider/slider.html
@@ -1,7 +1,7 @@
 <div class="slider">
   <div class="slider__content">
     <!-- aria-label should be customized for each carousel, and should not contain the word "carousel" -->
-    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, please customize for that use case -->
+    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, see testimonialSlider.html for an example -->
     <p-slider
       slides-per-view="auto"
       space-between="16"

--- a/resources/styles/organisms/slider/slider.html
+++ b/resources/styles/organisms/slider/slider.html
@@ -1,11 +1,14 @@
 <div class="slider">
   <div class="slider__content">
+    <!-- aria-label should be customized for each carousel, and should not contain the word "carousel" -->
+    <!-- aria-labelledby should be used instead, if the carousel has a heading element that describes the carousel, please customize for that use case -->
     <p-slider
       slides-per-view="auto"
       space-between="16"
       navigation="true"
       pagination-clickable="true"
       loop="true"
+      aria-label="This should be customized for each carousel"
       :breakpoints="{
       768: 
         {

--- a/resources/styles/organisms/testimonialSlider/testimonialSlider.html
+++ b/resources/styles/organisms/testimonialSlider/testimonialSlider.html
@@ -3,10 +3,10 @@
     <use href="/main-icons-sprite.svg#quote" />
   </svg>
   <div class="slider__callout">
-    <span class="h3"> Don’t take our word for it, read some of our thoughtful testimonials and decide for yourself. </span>
+    <span id="testimonial-slider-heading" class="h3"> Don’t take our word for it, read some of our thoughtful testimonials and decide for yourself. </span>
   </div>
   <div class="slider__content">
-    <p-slider slides-per-view="auto" space-between="32" navigation="true" pagination-clickable="true" loop="true">
+    <p-slider slides-per-view="auto" space-between="32" navigation="true" pagination-clickable="true" loop="true" aria-labelledby="testimonial-slider-heading">
       <swiper-slide loading="lazy">
         <blockquote class="testimonial">
           <p class="testimonial__content">Suspendisse ac blandit nisi, non tempor purus. Pellentesque ornare tellus molestie quam pretium aliquet. Mauris eu est at velit cursus rutrum non sit amet turpis. Phasellus mauris est, fermentum sit amet tincidunt ultricies, egestas a ante proin et eros rutrum urna sollicitudin euismod non ut sem!</p>

--- a/resources/styles/organisms/tiles/index.scss
+++ b/resources/styles/organisms/tiles/index.scss
@@ -1,4 +1,4 @@
-@use '@imarc/pronto/resources/styles/imported' as *;
+@use '@/core' as *;
 
 .tiles {
   $b: &;


### PR DESCRIPTION
Set up our current PSlider instance to follow the guidelines in the w3.org carousel pattern (https://www.w3.org/WAI/ARIA/apg/patterns/carousel/). 

Added an autoplaying slider to set up the additional accessibility features needed for those

Added a readme in the styles/organisms/slider folder with a breakdown of all of the parts needed to make a slider accessible for basic and autoplaying variants.